### PR TITLE
Merge alandtse/dev

### DIFF
--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -481,8 +481,8 @@ def setup_alexa(hass, config, login_obj):
          ['entities']) = {'media_player': {}}
         (hass.data[DATA_ALEXAMEDIA]
          ['accounts'][email]['new_devices']) = True  # force initial update
+        track_time_interval(hass, lambda now: update_devices(), scan_interval)
     update_devices()
-    track_time_interval(hass, lambda now: update_devices(), scan_interval)
     hass.services.register(DOMAIN, SERVICE_UPDATE_LAST_CALLED,
                            last_call_handler, schema=LAST_CALL_UPDATE_SCHEMA)
 

--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -416,8 +416,8 @@ def setup_alexa(hass, config, login_obj):
                                               hide_email(email)))[0:32],
                               {'player_state': json_payload})
             elif command == 'PUSH_DOPPLER_CONNECTION_CHANGE':
-                # Player volume update
-                _LOGGER.debug("Updating media_player avalibility %s",
+                # Player availability update
+                _LOGGER.debug("Updating media_player availability %s",
                               json_payload)
                 hass.bus.fire(('{}_{}'.format(DOMAIN,
                                               hide_email(email)))[0:32],

--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -239,12 +239,14 @@ def setup_alexa(hass, config, login_obj):
         """Ping Alexa API to identify all devices, bluetooth, and last called device.
 
         This will add new devices and services when discovered. By default this
-        runs every SCAN_INTERVAL seconds unless another method calls it. While
-        throttled at MIN_TIME_BETWEEN_SCANS, care should be taken to reduce the
-        number of runs to avoid flooding. Slow changing states should be
-        checked here instead of in spawned components like media_player since
-        this object is one per account.
-        Each AlexaAPI call generally results in one webpage request.
+        runs every SCAN_INTERVAL seconds unless another method calls it. if
+        websockets is connected, it will return immediately unless
+        'new_devices' has been set to True.
+        While throttled at MIN_TIME_BETWEEN_SCANS, care should be taken to
+        reduce the number of runs to avoid flooding. Slow changing states
+        should be checked here instead of in spawned components like
+        media_player since this object is one per account.
+        Each AlexaAPI call generally results in two webpage requests.
         """
         from alexapy import AlexaAPI
         existing_serials = (hass.data[DATA_ALEXAMEDIA]
@@ -474,7 +476,7 @@ def setup_alexa(hass, config, login_obj):
         (hass.data[DATA_ALEXAMEDIA]['accounts'][email]
          ['entities']) = {'media_player': {}}
         (hass.data[DATA_ALEXAMEDIA]
-         ['accounts'][email]['new_devices']) = True
+         ['accounts'][email]['new_devices']) = True  # force initial update
     update_devices()
     track_time_interval(hass, lambda now: update_devices(), scan_interval)
     hass.services.register(DOMAIN, SERVICE_UPDATE_LAST_CALLED,

--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -443,6 +443,7 @@ def setup_alexa(hass, config, login_obj):
                 _LOGGER.debug("Discovered new media_player %s", serial)
                 (hass.data[DATA_ALEXAMEDIA]
                  ['accounts'][email]['new_devices']) = True
+                update_devices(no_throttle=True)
 
     def ws_close_handler():
         """Handle websocket close.

--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -257,6 +257,11 @@ def setup_alexa(hass, config, login_obj):
                              [email]
                              ['entities']
                              ['media_player'].values())
+        if (hass.data[DATA_ALEXAMEDIA]['accounts'][email]['websocket']
+                and not (hass.data[DATA_ALEXAMEDIA]
+                         ['accounts'][email]['new_devices'])):
+            return
+        hass.data[DATA_ALEXAMEDIA]['accounts'][email]['new_devices'] = False
         devices = AlexaAPI.get_devices(login_obj)
         bluetooth = AlexaAPI.get_bluetooth(login_obj)
         _LOGGER.debug("%s: Found %s devices, %s bluetooth",
@@ -423,6 +428,16 @@ def setup_alexa(hass, config, login_obj):
                 hass.bus.fire(('{}_{}'.format(DOMAIN,
                                               hide_email(email)))[0:32],
                               {'player_state': json_payload})
+                player_state = json_payload['player_state']
+                serial = (player_state['dopplerId']['deviceSerialNumber'])
+                if (serial not in (hass.data[DATA_ALEXAMEDIA]
+                                   ['accounts']
+                                   [email]
+                                   ['entities']
+                                   ['media_player'].keys())):
+                    _LOGGER.debug("Discovered new media_player %s", serial)
+                    (hass.data[DATA_ALEXAMEDIA]
+                     ['accounts'][email]['new_devices']) = True
 
     def ws_close_handler():
         """Handle websocket close.

--- a/alexa_media/__init__.py
+++ b/alexa_media/__init__.py
@@ -451,8 +451,12 @@ def setup_alexa(hass, config, login_obj):
     email = login_obj.email
     (hass.data[DOMAIN]['accounts'][email]['websocket']) = ws_connect()
     (hass.data[DOMAIN]['accounts'][email]['login_obj']) = login_obj
-    (hass.data[DOMAIN]['accounts'][email]['devices']) = {'media_player': {}}
-    (hass.data[DOMAIN]['accounts'][email]['entities']) = {'media_player': {}}
+    if 'devices' not in hass.data[DOMAIN]['accounts'][email]:
+        (hass.data[DOMAIN]['accounts'][email]
+         ['devices']) = {'media_player': {}}
+    if 'entities' not in hass.data[DOMAIN]['accounts'][email]:
+        (hass.data[DOMAIN]['accounts'][email]
+         ['entities']) = {'media_player': {}}
     update_devices()
     track_time_interval(hass, lambda now: update_devices(), scan_interval)
     hass.services.register(DOMAIN, SERVICE_UPDATE_LAST_CALLED,

--- a/alexa_media/media_player.py
+++ b/alexa_media/media_player.py
@@ -518,7 +518,9 @@ class AlexaClient(MediaPlayerDevice):
             return
         self.alexa_api.set_volume(volume)
         self._media_vol_level = volume
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     @property
     def volume_level(self):
@@ -551,7 +553,9 @@ class AlexaClient(MediaPlayerDevice):
                 self.alexa_api.set_volume(self._previous_volume)
             else:
                 self.alexa_api.set_volume(50)
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     def media_play(self):
         """Send play command."""
@@ -559,7 +563,9 @@ class AlexaClient(MediaPlayerDevice):
                 and self.available):
             return
         self.alexa_api.play()
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     def media_pause(self):
         """Send pause command."""
@@ -567,7 +573,9 @@ class AlexaClient(MediaPlayerDevice):
                 and self.available):
             return
         self.alexa_api.pause()
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     def turn_off(self):
         """Turn the client off.
@@ -594,7 +602,9 @@ class AlexaClient(MediaPlayerDevice):
                 and self.available):
             return
         self.alexa_api.next()
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     def media_previous_track(self):
         """Send previous track command."""
@@ -602,7 +612,9 @@ class AlexaClient(MediaPlayerDevice):
                 and self.available):
             return
         self.alexa_api.previous()
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     def send_tts(self, message):
         """Send TTS to Device.
@@ -637,7 +649,9 @@ class AlexaClient(MediaPlayerDevice):
         else:
             self.alexa_api.play_music(media_type, media_id,
                                       customer_id=self._customer_id, **kwargs)
-        self.update()
+        if not (self.hass.data[DATA_ALEXAMEDIA]
+                ['accounts'][self._login.email]['websocket']):
+            self.update()
 
     @property
     def device_state_attributes(self):

--- a/alexa_media/media_player.py
+++ b/alexa_media/media_player.py
@@ -207,12 +207,10 @@ class AlexaClient(MediaPlayerDevice):
                     if (self.hass and self.schedule_update_ha_state):
                         self.schedule_update_ha_state()
                 elif 'dopplerConnectionState' in player_state:
-                    if player_state['dopplerConnectionState'] == "ONLINE":
-                        self._available = True
-                    else:
-                        self._available = False
+                    self._available = (player_state['dopplerConnectionState']
+                                       == "ONLINE")
                     if (self.hass and self.schedule_update_ha_state):
-                                self.schedule_update_ha_state()
+                        self.schedule_update_ha_state()
 
     def _clear_media_details(self):
         """Set all Media Items to None."""


### PR DESCRIPTION
Per our discussion in #132, this completely disables polling if websocket is detected. It also will do new device detection based on websockets. Should resolve #132. 

It does **not** handle bluetooth changes so is not a complete fix until your bluetooth update changes are merged in.  In theory you could simply force update_devices(no_throttle=True) after setting the `new_devices` key I mentioned in the other thread and the bluetooth update will be done as well.  Alternatively, you could move the bluetooth update over to it's own function which you would then call.

Also added some miscellaneous changes:

- Fix bug where reconnects would add known devices again (fix #124)
- Fix use of DATA_ALEXAMEDIA instead of DOMAIN to comply with HA requirements data store requirements
- Fix bug where we'd spawn multiple update_devices updates on reconnect