### PR TITLE
Fixed custom_updater URL for dev releases (readme.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Add this to your configuration:
 custom_updater:
   component_urls:
 # Dev build (unstable)
-    - https://raw.githubusercontent.com/keatontaylor/alexa_media_player/next/custom_components.json
+    - https://raw.githubusercontent.com/keatontaylor/alexa_media_player/dev/custom_components.json
 # Released build
     - https://raw.githubusercontent.com/keatontaylor/alexa_media_player/master/custom_components.json
 ```


### PR DESCRIPTION
Replaced 'next' with 'dev' in the URL